### PR TITLE
detect browser capabilities and redirect to a browsers download page

### DIFF
--- a/src/compatibilite.html
+++ b/src/compatibilite.html
@@ -1,0 +1,67 @@
+---
+layout: intro
+title: "Cette application requiert un navigateur compatible"
+---
+
+<p>L'Index Egapro est accessible depuis la plupart des navigateurs à jour.</p>
+
+<p>Les navigateurs suivants sont compatibles:</p>
+
+<section>
+  <article>
+    <h2>Mozilla Firefox</h2>
+    <a href="https://www.mozilla.org/firefox/">
+      <img
+        src="https://upload.wikimedia.org/wikipedia/commons/thumb/a/a0/Firefox_logo%2C_2019.svg/200px-Firefox_logo%2C_2019.svg.png"
+        alt="Firefox logo">
+      Télécharger Firefox
+    </a>
+  </article>
+
+  <article>
+    <h2>Microsoft Edge</h2>
+    <a href="https://www.microsoft.com/fr-fr/edge">
+      <img src="https://upload.wikimedia.org/wikipedia/commons/8/8b/Microsoft_Edge_logo.png" alt="Edge logo">
+      Télécharger Edge
+    </a>
+  </article>
+
+  <article>
+    <h2>Google Chrome</h2>
+    <a href="https://www.google.com/chrome/">
+      <img
+        src="https://upload.wikimedia.org/wikipedia/commons/thumb/e/e2/Google_Chrome_icon_%282011%29.svg/240px-Google_Chrome_icon_%282011%29.svg.png"
+        alt="Google Chrome logo">
+      Télécharger Google Chrome
+    </a>
+  </article>
+</section>
+
+<p class="others">Ainsi que <a href="https://brave.com/download/">Brave</a>, <a href="https://www.opera.com/">Opera</a>, Safari et d'autres…</p>
+
+<style>
+  article {
+    display: inline-block;
+    margin-right: 1rem;
+    padding-right: 1rem;
+    border-right: 1px solid #eee;
+    text-align: center;
+    width: 28%;
+    vertical-align: top;
+  }
+
+  article img,
+  article a {
+    display: block;
+    margin: 0 auto;
+  }
+
+  article img {
+    width: 80%;
+    max-width: 200px;
+  }
+
+  .others {
+    margin-top: 3rem;
+  }
+</style>

--- a/src/index.html
+++ b/src/index.html
@@ -1,6 +1,17 @@
 ---
 layout: empty
 ---
+<script>
+  // First, check the browser is compatible
+  try {
+    eval("async function _(){}")
+  }
+  catch (e) {
+    window.location.href = '{{site.baseurl}}/compatibilite.html'
+  }
+</script>
+
+
 <script src="{{ site.baseurl }}/assets/js/utils.js"></script>
 <script>
   document.onready = () => {


### PR DESCRIPTION
When the browser does not have the `async/await` capabilities, the user is redirected to a "browser download" page.

`async/await` is chosen as it is the most advanced feature a browser can get and is actively used in the app.

<img width="901" alt="Screen Shot 2020-12-04 at 19 30 13" src="https://user-images.githubusercontent.com/145172/101201956-d4d29000-3668-11eb-9f3c-e9461287fe41.png">
