### PR TITLE
[WIP] only allow modifying a validated declaration if it's in the status 'brouillon'

### DIFF
--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -18,10 +18,17 @@
     statut "brouillon" : elle sera alors modifiable, et remplacera votre
     déclaration actuelle une fois que vous l'aurez totalement validée jusqu'à
     la dernière étape.
-    <button>Modifier la déclaration</button>
+    <button onclick="setDraftStatus()">Modifier la déclaration</button>
   </details>
 </header>
 
+<header id="declaration-draft" style="display: none">
+  <div>
+    <hgroup>
+      <h1>Cette déclaration a déjà été validée, vous êtes en train de modifier un brouillon.</h1>
+    </hgroup>
+  </div>
+</header>
 
 <header>
   <div>

--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -6,6 +6,23 @@
 <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/solen.css">
 <script src="{{ site.baseurl }}/assets/js/utils.js"></script>
 
+<header id="declaration-readonly" style="display: none">
+  <div>
+    <hgroup>
+      <h1>Cette déclaration a déjà été validée, aucune modification saisie ne sera enregistrée.</h1>
+    </hgroup>
+  </div>
+  <details>
+    <summary>Modifier la déclaration</summary>
+    Si vous souhaitez modifier la déclaration, vous pouvez la passer en
+    statut "brouillon" : elle sera alors modifiable, et remplacera votre
+    déclaration actuelle une fois que vous l'aurez totalement validée jusqu'à
+    la dernière étape.
+    <button>Modifier la déclaration</button>
+  </details>
+</header>
+
+
 <header>
   <div>
     <img src="{{ site.baseurl }}/assets/img/marianne.png" alt="Marianne">

--- a/src/assets/js/tunnel.js
+++ b/src/assets/js/tunnel.js
@@ -59,7 +59,12 @@ const step = steps.findIndex((step) => step.name === pageName);
 document.addEventListener("ready", () => {
   if (!app.token) location.href = "/";
   loadFormValues(form, app.data);
-  if (app.data?.déclaration?.date) {
+  // TODO: uncomment this line when the API accepts this
+  //if (app.data?.déclaration?.statut === "brouillon") {
+  // TOTO: remove this line
+  if (app.data._statut === "brouillon") {
+    document.getElementById("declaration-draft").style = "display: block" 
+  } else if (app.data?.déclaration?.date) {
     document.getElementById("declaration-readonly").style = "display: block" 
   }
 });
@@ -93,7 +98,7 @@ form.addEventListener("submit", async (event) => {
       return alert(e)
     }
   }
-  if (app.data?.déclaration?.date) {
+  if (app.data?.déclaration?.date && steps[step].name !== "validation") {
     alert("La déclaration a déjà été validée, les modifications éventuelles apportées à ce formulaire ne seront pas sauvegardées.")
   } else {
     const response = await saveFormData(event);
@@ -272,5 +277,17 @@ function delVal(data, flatKey) {
     delete item[key][index];
   } else {
     delete item[key];
+  }
+}
+
+function setDraftStatus() {
+  if (confirm("Vous allez passer cette déclaration en mode brouillon, elle ne remplacera celle que vous avez déjà validée qu'une fois que vous serez allé jusqu'à la dernière étape")) {
+    document.getElementById("declaration-readonly").style = "display: none" 
+    document.getElementById("declaration-draft").style = "display: block" 
+    // TODO: uncomment this once the API allows it
+    //app.data.déclaration.statut = "brouillon"
+    // TODO: remove this line
+    app.data._statut = "brouillon"
+    app.save()
   }
 }

--- a/src/assets/js/tunnel.js
+++ b/src/assets/js/tunnel.js
@@ -98,7 +98,12 @@ form.addEventListener("submit", async (event) => {
       return alert(e)
     }
   }
-  if (app.data?.déclaration?.date && steps[step].name !== "validation") {
+  if (app.data?.déclaration?.date
+      && steps[step].name !== "validation"
+      // TODO: uncomment this once the API allows it
+      //&& app.data.déclaration.statut !== "brouillon") {
+      // TODO: remove the following line
+      && app.data._statut !== "brouillon") {
     alert("La déclaration a déjà été validée, les modifications éventuelles apportées à ce formulaire ne seront pas sauvegardées.")
   } else {
     const response = await saveFormData(event);

--- a/src/assets/js/tunnel.js
+++ b/src/assets/js/tunnel.js
@@ -59,6 +59,9 @@ const step = steps.findIndex((step) => step.name === pageName);
 document.addEventListener("ready", () => {
   if (!app.token) location.href = "/";
   loadFormValues(form, app.data);
+  if (app.data?.déclaration?.date) {
+    document.getElementById("declaration-readonly").style = "display: block" 
+  }
 });
 
 progress.max = steps.length - 1;
@@ -90,9 +93,13 @@ form.addEventListener("submit", async (event) => {
       return alert(e)
     }
   }
-  const response = await saveFormData(event);
+  if (app.data?.déclaration?.date) {
+    alert("La déclaration a déjà été validée, les modifications éventuelles apportées à ce formulaire ne seront pas sauvegardées.")
+  } else {
+    const response = await saveFormData(event);
 
-  if (!response.ok) return;
+    if (!response.ok) return;
+  }
 
   const nextStep = steps[step].nextStep;
   if (nextStep) return redirect(`${nextStep(app.data)}.html`);

--- a/src/validation.html
+++ b/src/validation.html
@@ -23,5 +23,9 @@ jointe, l'ensemble des informations saisies.</p>
     // To "déclare" the declaration, we need to send its `déclaration.date`.
     // Also, Javascript has this thing where it puts a Z instead of `+00:00`.
     app.data.déclaration.date = new Date().toISOString().slice(0, -1) + "+00:00"
+    // TODO: uncomment this line when the API accepts it
+    //app.data.déclaration.status = "final"
+    // TODO: remove this line
+    app.data._statut = "final"
   }
 </script>


### PR DESCRIPTION
Until the API is updated to accept `déclaration.statut` we set `_statut` locally.

This is how the header looks like when the declaration has already been validated:
<img width="803" alt="Capture d’écran 2020-12-10 à 17 49 13" src="https://user-images.githubusercontent.com/167767/101802757-17d0af80-3b10-11eb-9620-3974ccd4f327.png">

This is how the header looks like when the declaration has already been validated, but is set as draft:
<img width="805" alt="Capture d’écran 2020-12-10 à 17 49 58" src="https://user-images.githubusercontent.com/167767/101802844-320a8d80-3b10-11eb-949c-c09e324f57bf.png">

(Yes we do need some CSS :P)