### PR TITLE
New user flow

### DIFF
--- a/src/assets/js/tunnel.js
+++ b/src/assets/js/tunnel.js
@@ -136,12 +136,10 @@ if (step > 0) {
   };
 } else {
   previousButton.onclick = (e) => {
-    // On the "commencer.html" page (the first) we display a "recommencer" button
+    // On the "commencer.html" page (the first) we display a "nouvelle déclaration" button
     e.preventDefault();
-    app.resetData()
-    delete localStorage.data
     // Reload the page, without the local data
-    location.pathname = location.pathname
+    location.pathname = './'
   };
 }
 

--- a/src/assets/js/utils.js
+++ b/src/assets/js/utils.js
@@ -193,6 +193,10 @@ class AppStorage {
     this.data = { source: 'formulaire' }
   }
 
+  dataToLocalStorage() {
+    localStorage.data = JSON.stringify(this.data)
+  }
+
   async loadConfig() {
     const response = await request('GET', '/config')
     if(!response.ok) notify.error("Le serveur ne répond pas. Veuillez contacter l'équipe technique.")
@@ -244,8 +248,16 @@ class AppStorage {
     }, {})
   }
 
+  set annee(annee) {
+    return this.setItem('déclaration.année_indicateurs', Number(annee))
+  }
+
   get annee() {
     return this.getItem('déclaration.année_indicateurs')
+  }
+
+  set siren(siren) {
+    return this.setItem('entreprise.siren', siren)
   }
 
   get siren() {
@@ -344,7 +356,7 @@ class AppStorage {
     const response = await request('PUT', `/declaration/${this.siren}/${this.annee}`, schemaData)
     if(response.ok) {
       Object.assign(this.data, schemaData)
-      localStorage.data = JSON.stringify(this.data)
+      this.dataToLocalStorage()
     }
     // Only alert if we have an event: if we were called from a form submit (not from a `refreshForm`)
     else if(response.data.error && event) notify.error(response.data.error)

--- a/src/commencer.html
+++ b/src/commencer.html
@@ -1,7 +1,7 @@
 ---
 layout: tunnel
 title: "Commencer la déclaration"
-prevButtonLabel: "Recommencer"
+prevButtonLabel: "Nouvelle déclaration"
 ---
 <h1>{{ page.title }}</h1>
   <fieldset>
@@ -16,8 +16,6 @@ prevButtonLabel: "Recommencer"
   </fieldset>
 
 <script>
-  delete localStorage.data
-
   document.preFormSubmit = event => {
     const anneeIndicateurs = Number(selectField("déclaration.année_indicateurs").value)
     const message = `Vous allez procéder à la déclaration de votre index de l’égalité professionnelle pour l’année ${anneeIndicateurs + 1} au titre des données de ${anneeIndicateurs}.`

--- a/src/index.html
+++ b/src/index.html
@@ -15,13 +15,22 @@ layout: empty
 <script src="{{ site.baseurl }}/assets/js/utils.js"></script>
 <script>
   document.onready = () => {
-    const tokenParam = '?token='
-    let token = false
-    if(location.search.startsWith(tokenParam)) {
-      token = true
-      app.token = location.search.slice(tokenParam.length)
+    const urlParams = new URLSearchParams(location.search)
+    app.resetData()
+
+    if (urlParams.has('token')) {
+      // Coming from an "authentication link" in the confirmation email
+      app.token = urlParams.get('token')
+    } else if (urlParams.has('siren') && urlParams.has('year')) {
+      // Coming from a "declaration link" from the declaration validation email
+      app.siren = urlParams.get('siren')
+      app.annee = urlParams.get('year')
+    } else {
+      // Start from scratch
+      delete localStorage.email
+      delete localStorage.token
     }
-    else if (app.token) token = true
-    token ? redirect('{{site.baseurl}}/commencer.html') : redirect('{{site.baseurl}}/presentation.html')
+    app.dataToLocalStorage()
+    redirect(app.token ? 'commencer.html' : 'presentation.html')
   }
 </script>

--- a/src/transmission.html
+++ b/src/transmission.html
@@ -15,9 +15,9 @@ de procédure.
 <p class=warning>Si vous ne recevez pas cet accusé de réception, merci de bien vérifier que
 celui-ci n'a pas été déplacé dans votre dossier de courriers indésirables. Si
 toutefois vous ne l'avez pas reçu, <em>il est important de ne pas faire une
-nouvelle déclaration</em>. Vous pouvez revenir sur votre déclaration, via le lien
-transmis dans l'email de validation de votre adresse électronique, à la
-dernière page de validation afin de générer l'envoi d'un nouvel accusé de
-réception.</p>
+nouvelle déclaration</em>. Vous pouvez revenir sur votre déclaration via le lien
+transmis dans l'email qui vient de vous être envoyé.</p>
 
 <center>Nous vous remercions de votre transmission.</center>
+
+<p>Si vous le souhaitez, vous pouvez effectuer une <a href="./">nouvelle déclaration</a>.</p>


### PR DESCRIPTION
Changement dans la gestion des emails/token/siren/année :

1/ quelqu'un qui arrive sur `/declaration/` va être vu comme quelqu'un qui démarre juste : on va lui demander son email, lui envoyer un mail avec le lien avec le token
2/ quelqu'un qui arrive sur `/declaration/?token=<le token>` va être vu comme quelqu'un qui vient de s'identifier : il sera redirigé vers `/declaration/commencer.html`
3/ quelqu'un qui arrive sur `/declaration/?siren=123456782&year=2019` va être vu comme quelqu'un qui a déjà au moins commencé sa déclaration. Si il a déjà un token valide il sera redirigé vers `/declaration/commencer.html`, autrement on lui demander son email, et avec le lien avec le token il arrivera en 2/, mais avec l'année et le siren déjà pré-remplis

Plusieurs avantages :

- à la fin du processus quand on lui envoie un mail de confirmation de la transmission de sa déclaration, on y met le lien avec `?siren=...&year=...` : pas de risque d'avoir un token expiré, cette URL sera toujours valade (et si il a toujours un token valide alors il arrive sur `commencer.html` comme si il était en train de revoir sa déclaration, sinon on lui demande d'abord son email pour lui envoyer le lien avec token)
- à la fin du processus, ou à tout moment, on peut redémarrer une nouvelle déclaration avec un nouvel email en suivant
  - le lien qui est sur la toute dernière page
  - le bouton "recommencer une déclaration" qui est sur la page `commencer.html`
   - le lien qui est sur la page d'accueil de egapro